### PR TITLE
removed StrictMode from react to prevent component re-rendering

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,9 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
According to React Strict Mode documentation (https://reactjs.org/docs/strict-mode.html) 

Strict mode causes the component to render twice in development mode. Removed it to prevent re-rendering.

